### PR TITLE
corrected d8 detection, and simplesamlauth_lib path settings

### DIFF
--- a/sites/default/settings.redirects-allsites.php
+++ b/sites/default/settings.redirects-allsites.php
@@ -47,12 +47,14 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
 #
 # Above document says to use _ENV[HOME], but _SERVER[DOCUMENT_ROOT] handles whether there is a web directory
 #
-if (isset($_ENV['HOME']) && php_sapi_name() != 'cli') {
+if (isset($_ENV['HOME'])) {
     if (isD8()) {
-        $settings['simplesamlphp_dir'] = $_SERVER['DOCUMENT_ROOT'] . '/private/simplesamlphp';
+        $settings['simplesamlphp_dir'] = getDocRoot() . '/private/simplesamlphp';
+	// print("settings['simplesamlphp_dir'] = '" . $settings['simplesamlphp_dir'] . "'\n");
     }
     else {
-        $conf['simplesamlphp_auth_installdir'] = $_SERVER['DOCUMENT_ROOT'] . '/private/simplesamlphp';
+        $conf['simplesamlphp_auth_installdir'] = getDocRoot(). '/private/simplesamlphp';
+	// print("conf['simplesamlphp_auth_installdir'] = '" . $conf['simplesamlphp_auth_installdir'] . "'\n");
     }
 }
 

--- a/sites/default/settings.redirects-functions.php
+++ b/sites/default/settings.redirects-functions.php
@@ -14,7 +14,15 @@ function isD7() {
 }
 
 function isD8() {
-	return(isset($_ENV['HOME']) && (file_exists($_ENV['HOME'].'/web') || file_exists($_SERVER['DOCUMENT_ROOT'].'/modules/contrib')));
+	return(isset($_ENV['HOME']) && (file_exists($_ENV['HOME'].'/code/web') || file_exists($_ENV['HOME'].'/code/modules/contrib')));
+}
+
+function getDocRoot() {
+	if (isset($_ENV['HOME']) && (file_exists($_ENV['HOME'].'/code/web'))) {
+		return($_ENV['HOME'].'/code/web');
+	}
+
+	return($_ENV['HOME'].'/code');
 }
 
 function isProxied() {


### PR DESCRIPTION
A number of pantheon functions seem to use dursh (hence cli) to perform their functions.
The guard on line 50 of sites/default/settings.redirects-allsites.php was preventing simplesaml from being initialized correctly.
Testing with drush also shows that _SERVER[DOCUMENT_ROOT] was not being set under drush, while _ENV['HOME'] is being set correctly under both drush and nginx.

There is now a getDocRoot function for returning the web root of a site.
Also corrected the paths to include the /code segment.

These corrections should fix the pantheon dashboard check that simplesaml is installed correctly.